### PR TITLE
Update responses usage for Azure

### DIFF
--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -798,9 +798,9 @@ export class AgentLoop {
               .filter(Boolean)
               .join("\n");
 
+            const provider = this.config.provider?.toLowerCase();
             const responseCall =
-              !this.config.provider ||
-              this.config.provider?.toLowerCase() === "openai"
+              !provider || provider === "openai" || provider === "azure"
                 ? (params: ResponseCreateParams) =>
                     this.oai.responses.create(params)
                 : (params: ResponseCreateParams) =>
@@ -1186,9 +1186,9 @@ export class AgentLoop {
                 .filter(Boolean)
                 .join("\n");
 
+              const provider = this.config.provider?.toLowerCase();
               const responseCall =
-                !this.config.provider ||
-                this.config.provider?.toLowerCase() === "openai"
+                !provider || provider === "openai" || provider === "azure"
                   ? (params: ResponseCreateParams) =>
                       this.oai.responses.create(params)
                   : (params: ResponseCreateParams) =>


### PR DESCRIPTION
## Summary
- allow Azure provider to use the Responses API rather than falling back to Chat Completions

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*
- `pnpm typecheck` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*