### PR TITLE
Use Azure threads endpoints for Responses

### DIFF
--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -22,7 +22,10 @@ import {
 } from "../config.js";
 import { log } from "../logger/log.js";
 import { parseToolCallArguments } from "../parsers.js";
-import { responsesCreateViaChatCompletions } from "../responses.js";
+import {
+  responsesCreateViaChatCompletions,
+  azureResponsesCreate,
+} from "../responses.js";
 import {
   ORIGIN,
   getSessionId,
@@ -798,11 +801,16 @@ export class AgentLoop {
               .filter(Boolean)
               .join("\n");
 
-            const responseCall =
-              !this.config.provider ||
-              this.config.provider?.toLowerCase() === "openai"
+            const provider = this.config.provider?.toLowerCase();
+            const responseCall = !provider || provider === "openai"
+              ? (params: ResponseCreateParams) =>
+                  this.oai.responses.create(params)
+              : provider === "azure"
                 ? (params: ResponseCreateParams) =>
-                    this.oai.responses.create(params)
+                    azureResponsesCreate(
+                      this.oai as AzureOpenAI,
+                      params as ResponseCreateParams & { stream: true },
+                    )
                 : (params: ResponseCreateParams) =>
                     responsesCreateViaChatCompletions(
                       this.oai,
@@ -1186,11 +1194,16 @@ export class AgentLoop {
                 .filter(Boolean)
                 .join("\n");
 
-              const responseCall =
-                !this.config.provider ||
-                this.config.provider?.toLowerCase() === "openai"
+              const provider = this.config.provider?.toLowerCase();
+              const responseCall = !provider || provider === "openai"
+                ? (params: ResponseCreateParams) =>
+                    this.oai.responses.create(params)
+                : provider === "azure"
                   ? (params: ResponseCreateParams) =>
-                      this.oai.responses.create(params)
+                      azureResponsesCreate(
+                        this.oai as AzureOpenAI,
+                        params as ResponseCreateParams & { stream: true },
+                      )
                   : (params: ResponseCreateParams) =>
                       responsesCreateViaChatCompletions(
                         this.oai,

--- a/codex-cli/src/utils/responses.ts
+++ b/codex-cli/src/utils/responses.ts
@@ -315,6 +315,42 @@ async function responsesCreateViaChatCompletions(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Azure Responses API via `/openai/threads`
+// ---------------------------------------------------------------------------
+async function azureResponsesCreate(
+  openai: OpenAI,
+  input: ResponseCreateInput,
+): Promise<AsyncGenerator<ResponseEvent>> {
+  // NOTE: This is a lightweight shim that maps the Responses API onto the
+  // Azure "threads" endpoints. It currently only handles the common case of
+  // streaming a single user message. Complex sequences like resuming threads
+  // or sending tool outputs may require additional logic.
+
+  const messages = input.input.flatMap((item) => {
+    if (item.type !== "message") {
+      return [];
+    }
+    return item.content
+      .filter((c) => c.type === "input_text")
+      .map((c) => ({ role: item.role, content: c.text ?? "" }));
+  });
+
+  // @ts-expect-error Azure SDK does not yet type this helper
+  const stream = (await openai.beta.threads.createAndRun({
+    thread: { messages },
+    model: input.model,
+    instructions: input.instructions,
+    tools: input.tools,
+    tool_choice: input.tool_choice,
+    temperature: input.temperature,
+    top_p: input.top_p,
+    stream: true,
+  })) as AsyncGenerator<ResponseEvent>;
+
+  return stream;
+}
+
 // Non-streaming implementation
 async function nonStreamResponses(
   input: ResponseCreateInput,
@@ -709,8 +745,9 @@ async function* streamResponses(
   }
 }
 
-export {
+export { 
   responsesCreateViaChatCompletions,
+  azureResponsesCreate,
   ResponseCreateInput,
   ResponseOutput,
   ResponseEvent,


### PR DESCRIPTION
## Summary
- add `azureResponsesCreate` helper calling Azure `/openai/threads` endpoints
- use that helper in `AgentLoop` when provider is Azure

## Testing
- `pnpm lint` *(fails: unable to download pnpm package)*
- `pnpm test` *(fails: unable to download pnpm package)*
- `pnpm typecheck` *(fails: unable to download pnpm package)*